### PR TITLE
Add My Prompts page, private badge, and form error toasts

### DIFF
--- a/src/app/(main)/my-prompts/page.tsx
+++ b/src/app/(main)/my-prompts/page.tsx
@@ -1,0 +1,49 @@
+import { redirect } from 'next/navigation'
+import Link from 'next/link'
+import { createClient } from '@/lib/supabase/server'
+import { getMyPrompts, getUserInteractions } from '@/lib/queries/prompts'
+import { PromptGrid } from '@/components/prompt/prompt-grid'
+import { Button } from '@/components/ui/button'
+import { Plus } from 'lucide-react'
+
+export const metadata = { title: 'My Prompts — PromptVault' }
+
+export default async function MyPromptsPage() {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+
+  if (!user) redirect('/login?next=/my-prompts')
+
+  const prompts = await getMyPrompts(user.id)
+  const promptIds = prompts.map((p) => p.id)
+  const { likes, bookmarks } = await getUserInteractions(user.id, promptIds)
+
+  const publicCount = prompts.filter((p) => p.is_public).length
+  const privateCount = prompts.length - publicCount
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">My Prompts</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {publicCount} public · {privateCount} private
+          </p>
+        </div>
+        <Button asChild size="sm">
+          <Link href="/prompts/new">
+            <Plus className="mr-1 h-4 w-4" />
+            New Prompt
+          </Link>
+        </Button>
+      </div>
+      <PromptGrid
+        prompts={prompts}
+        likedIds={likes}
+        bookmarkedIds={bookmarks}
+        isAuthenticated={true}
+        emptyMessage="You haven't created any prompts yet. Share your first one!"
+      />
+    </div>
+  )
+}

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -69,6 +69,9 @@ export async function Navbar() {
                     <Link href={`/profile/${profile?.username}`}>Profile</Link>
                   </DropdownMenuItem>
                   <DropdownMenuItem asChild>
+                    <Link href="/my-prompts">My Prompts</Link>
+                  </DropdownMenuItem>
+                  <DropdownMenuItem asChild>
                     <Link href="/bookmarks">Bookmarks</Link>
                   </DropdownMenuItem>
                   <DropdownMenuItem asChild>

--- a/src/components/prompt/prompt-card.tsx
+++ b/src/components/prompt/prompt-card.tsx
@@ -7,6 +7,7 @@ import { LikeButton } from '@/components/prompt/like-button'
 import { BookmarkButton } from '@/components/prompt/bookmark-button'
 import { TagBadge } from '@/components/prompt/tag-badge'
 import { CopyButton } from '@/components/prompt/copy-button'
+import { Lock } from 'lucide-react'
 import type { PromptWithProfile } from '@/types/database'
 
 const MODEL_LABELS: Record<string, string> = {
@@ -39,9 +40,17 @@ export function PromptCard({ prompt, isLiked, isBookmarked, isAuthenticated }: P
           <h2 className="font-semibold leading-snug group-hover/card:text-primary transition-colors line-clamp-2 flex-1">
             {prompt.title}
           </h2>
-          <Badge variant="outline" className="shrink-0 text-xs relative z-10">
-            {MODEL_LABELS[prompt.model] ?? prompt.model}
-          </Badge>
+          <div className="flex shrink-0 gap-1 relative z-10">
+            {prompt.is_public === false && (
+              <Badge variant="secondary" className="text-xs gap-1">
+                <Lock className="h-3 w-3" />
+                Private
+              </Badge>
+            )}
+            <Badge variant="outline" className="text-xs">
+              {MODEL_LABELS[prompt.model] ?? prompt.model}
+            </Badge>
+          </div>
         </div>
         {prompt.description && (
           <p className="text-sm text-muted-foreground line-clamp-2 mt-1">{prompt.description}</p>

--- a/src/components/prompt/prompt-form.tsx
+++ b/src/components/prompt/prompt-form.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { useActionState } from 'react'
+import { useActionState, useEffect } from 'react'
 import { useFormStatus } from 'react-dom'
+import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
@@ -54,6 +55,12 @@ interface PromptFormProps {
 
 export function PromptForm({ action, prompt }: PromptFormProps) {
   const [state, formAction] = useActionState<FormState, FormData>(action, undefined)
+
+  useEffect(() => {
+    if (state?.error?.['_form']?.[0]) {
+      toast.error(state.error['_form'][0])
+    }
+  }, [state])
 
   return (
     <form action={formAction} className="space-y-6">

--- a/src/lib/queries/prompts.ts
+++ b/src/lib/queries/prompts.ts
@@ -86,6 +86,24 @@ export async function getUserPrompts(userId: string): Promise<PromptWithProfile[
   return (data ?? []) as unknown as PromptWithProfile[]
 }
 
+// Returns ALL prompts for the owner (public + private), includes is_public field
+export async function getMyPrompts(userId: string): Promise<PromptWithProfile[]> {
+  const supabase = await createClient()
+
+  const { data, error } = await supabase
+    .from('prompts')
+    .select(`
+      id, title, content, description, model, category, tags,
+      is_public, like_count, bookmark_count, created_at,
+      profiles!prompts_user_id_fkey(username, display_name, avatar_url)
+    `)
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false })
+
+  if (error) throw error
+  return (data ?? []) as unknown as PromptWithProfile[]
+}
+
 export async function searchPrompts(query: string, category?: string): Promise<PromptWithProfile[]> {
   const supabase = await createClient()
 


### PR DESCRIPTION
## Summary
- **My Prompts page** (`/my-prompts`): shows all of the logged-in user's prompts (public + private) with a count breakdown in the header
- **Private badge on cards**: any prompt with `is_public === false` now shows a lock icon + "Private" badge in the card header
- **Form error toasts**: `PromptForm` now fires `toast.error()` when a server-side `_form` error comes back (covers create and edit flows)
- **Navbar**: added "My Prompts" link in the user dropdown menu

## Test plan
- [ ] Log in → open avatar dropdown → click "My Prompts" → page loads with your prompts
- [ ] Create a private prompt (is_public = false) → it appears in My Prompts with the lock badge, but NOT in the public feed
- [ ] Submit the create/edit form with a bad payload → error toast fires bottom-right
- [ ] Unauthenticated visit to `/my-prompts` → redirects to `/login?next=/my-prompts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)