### PR TITLE
Author-first card redesign + working tag filtering

### DIFF
--- a/src/app/(main)/explore/page.tsx
+++ b/src/app/(main)/explore/page.tsx
@@ -25,11 +25,11 @@ function ExploreSkeleton() {
   )
 }
 
-async function ExploreResults({ query, category }: { query?: string; category?: string }) {
+async function ExploreResults({ query, category, tag }: { query?: string; category?: string; tag?: string }) {
   const supabase = await createClient()
   const { data: { user } } = await supabase.auth.getUser()
 
-  const prompts = await searchPrompts(query ?? '', category)
+  const prompts = await searchPrompts(query ?? '', category, tag)
   const promptIds = prompts.map((p) => p.id)
 
   const { likes, bookmarks } = user
@@ -50,9 +50,9 @@ async function ExploreResults({ query, category }: { query?: string; category?: 
 export default async function ExplorePage({
   searchParams,
 }: {
-  searchParams: Promise<{ q?: string; category?: string }>
+  searchParams: Promise<{ q?: string; category?: string; tag?: string }>
 }) {
-  const { q, category } = await searchParams
+  const { q, category, tag } = await searchParams
 
   return (
     <div className="space-y-6">
@@ -64,11 +64,11 @@ export default async function ExplorePage({
       </div>
 
       <Suspense>
-        <ExploreFilters categories={CATEGORIES} currentCategory={category} currentQuery={q} />
+        <ExploreFilters categories={CATEGORIES} currentCategory={category} currentQuery={q} currentTag={tag} />
       </Suspense>
 
       <Suspense fallback={<ExploreSkeleton />}>
-        <ExploreResults query={q} category={category} />
+        <ExploreResults query={q} category={category} tag={tag} />
       </Suspense>
     </div>
   )

--- a/src/components/feed/explore-filters.tsx
+++ b/src/components/feed/explore-filters.tsx
@@ -3,16 +3,17 @@
 import { useRouter, usePathname, useSearchParams } from 'next/navigation'
 import { Input } from '@/components/ui/input'
 import { Badge } from '@/components/ui/badge'
-import { Search } from 'lucide-react'
+import { Search, X } from 'lucide-react'
 import { useEffect, useRef, useTransition } from 'react'
 
 interface ExploreFiltersProps {
   categories: string[]
   currentCategory?: string
   currentQuery?: string
+  currentTag?: string
 }
 
-export function ExploreFilters({ categories, currentCategory, currentQuery }: ExploreFiltersProps) {
+export function ExploreFilters({ categories, currentCategory, currentQuery, currentTag }: ExploreFiltersProps) {
   const router = useRouter()
   const pathname = usePathname()
   const searchParams = useSearchParams()
@@ -39,6 +40,14 @@ export function ExploreFilters({ categories, currentCategory, currentQuery }: Ex
     })
   }
 
+  function clearTag() {
+    const params = new URLSearchParams(searchParams.toString())
+    params.delete('tag')
+    startTransition(() => {
+      router.push(`${pathname}?${params.toString()}`)
+    })
+  }
+
   return (
     <div className="space-y-4">
       <div className="relative">
@@ -56,6 +65,19 @@ export function ExploreFilters({ categories, currentCategory, currentQuery }: Ex
           }}
         />
       </div>
+
+      {/* Active tag chip */}
+      {currentTag && (
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-muted-foreground">Filtering by tag:</span>
+          <Badge variant="secondary" className="gap-1">
+            #{currentTag}
+            <button onClick={clearTag} className="ml-1 hover:text-foreground">
+              <X className="h-3 w-3" />
+            </button>
+          </Badge>
+        </div>
+      )}
 
       <div className="flex flex-wrap gap-2">
         {categories.map((cat) => {

--- a/src/components/prompt/prompt-card.tsx
+++ b/src/components/prompt/prompt-card.tsx
@@ -36,6 +36,28 @@ export function PromptCard({ prompt, isLiked, isBookmarked, isAuthenticated }: P
       <Link href={`/prompts/${prompt.id}`} className="absolute inset-0 z-0" aria-label={prompt.title} />
 
       <CardHeader className="pb-3">
+        {/* Author row — top of card, prominent */}
+        <Link
+          href={`/profile/${profile.username}`}
+          className="flex items-center gap-2.5 group/author relative z-10 mb-3"
+        >
+          <Avatar className="h-8 w-8 ring-2 ring-background">
+            <AvatarImage src={profile.avatar_url ?? undefined} />
+            <AvatarFallback className="text-xs font-semibold">
+              {(profile.display_name ?? profile.username ?? 'U')[0].toUpperCase()}
+            </AvatarFallback>
+          </Avatar>
+          <div className="flex flex-col min-w-0">
+            <span className="text-sm font-semibold leading-tight truncate group-hover/author:text-primary transition-colors">
+              {profile.display_name ?? profile.username}
+            </span>
+            <span className="text-xs text-muted-foreground">
+              {formatDistanceToNow(new Date(prompt.created_at), { addSuffix: true })}
+            </span>
+          </div>
+        </Link>
+
+        {/* Title + badges */}
         <div className="flex items-start justify-between gap-2">
           <h2 className="font-semibold leading-snug group-hover/card:text-primary transition-colors line-clamp-2 flex-1">
             {prompt.title}
@@ -52,6 +74,7 @@ export function PromptCard({ prompt, isLiked, isBookmarked, isAuthenticated }: P
             </Badge>
           </div>
         </div>
+
         {prompt.description && (
           <p className="text-sm text-muted-foreground line-clamp-2 mt-1">{prompt.description}</p>
         )}
@@ -75,23 +98,7 @@ export function PromptCard({ prompt, isLiked, isBookmarked, isAuthenticated }: P
         )}
       </CardContent>
 
-      <CardFooter className="pt-0 flex items-center justify-between">
-        <Link href={`/profile/${profile.username}`} className="flex items-center gap-2 group/author relative z-10">
-          <Avatar className="h-6 w-6">
-            <AvatarImage src={profile.avatar_url ?? undefined} />
-            <AvatarFallback className="text-xs">
-              {(profile.display_name ?? profile.username ?? 'U')[0].toUpperCase()}
-            </AvatarFallback>
-          </Avatar>
-          <span className="text-xs text-muted-foreground group-hover/author:text-foreground transition-colors">
-            {profile.display_name ?? profile.username}
-          </span>
-          <span className="text-xs text-muted-foreground">·</span>
-          <span className="text-xs text-muted-foreground">
-            {formatDistanceToNow(new Date(prompt.created_at), { addSuffix: true })}
-          </span>
-        </Link>
-
+      <CardFooter className="pt-0 flex items-center justify-end">
         <div className="flex items-center relative z-10">
           <LikeButton
             promptId={prompt.id}

--- a/src/lib/queries/prompts.ts
+++ b/src/lib/queries/prompts.ts
@@ -124,7 +124,7 @@ export async function getMyPrompts(userId: string): Promise<PromptWithProfile[]>
   return (data ?? []) as unknown as PromptWithProfile[]
 }
 
-export async function searchPrompts(query: string, category?: string): Promise<PromptWithProfile[]> {
+export async function searchPrompts(query: string, category?: string, tag?: string): Promise<PromptWithProfile[]> {
   const supabase = await createClient()
 
   let dbQuery = supabase
@@ -140,6 +140,10 @@ export async function searchPrompts(query: string, category?: string): Promise<P
 
   if (category && category !== 'all' && isPromptCategory(category)) {
     dbQuery = dbQuery.eq('category', category)
+  }
+
+  if (tag) {
+    dbQuery = dbQuery.contains('tags', [tag])
   }
 
   const { data, error } = await dbQuery


### PR DESCRIPTION
Closes #6, closes #10

## Changes

### Author-first card redesign (#6)
Every prompt card now leads with the creator, not the content:
- Avatar + name moved to the **top** of the card (was at the bottom in tiny text)
- Avatar size increased from 24px → 32px with a subtle ring
- Two-line author block: bold display name on top, relative timestamp below
- Like/bookmark stay at the bottom right

Before: author was an afterthought at the bottom
After: you see *who wrote it* before you read *what they wrote* — same as Twitter

### Tag filtering (#10)
Tags on cards already linked to `/explore?tag=...` but the query ignored that param. Now it works end-to-end:
- `searchPrompts()` accepts a `tag` param and filters with `.contains('tags', [tag])`
- Active tag shown as a removable chip above the category pills in ExploreFilters
- Click any `#tag` badge on any card → lands on Explore filtered to that tag

## Test plan
- [ ] Feed/My Prompts — author avatar + name appear at top of every card
- [ ] Click an author name on a card → goes to their profile
- [ ] Click a `#tag` badge → lands on `/explore?tag=...` with results filtered and chip shown
- [ ] Click X on the tag chip → clears the tag filter
- [ ] Tag + category filters can be combined

🤖 Generated with [Claude Code](https://claude.com/claude-code)