### PR TITLE
Add mobile bottom navigation for small screens (closes #8)

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -4,7 +4,7 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
   return (
     <>
       <Navbar />
-      <main className="mx-auto max-w-5xl px-4 py-6">{children}</main>
+      <main className="mx-auto max-w-5xl px-4 py-6 pb-24 sm:pb-6">{children}</main>
     </>
   )
 }

--- a/src/components/layout/mobile-bottom-nav.tsx
+++ b/src/components/layout/mobile-bottom-nav.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { cn } from '@/lib/utils'
+import { Compass, Home, LogIn, PlusSquare, User, UserPlus, Bookmark } from 'lucide-react'
+
+interface MobileBottomNavProps {
+  isAuthenticated: boolean
+  username?: string
+}
+
+type NavItem = {
+  href: string
+  label: string
+  icon: React.ComponentType<{ className?: string }>
+  active: (pathname: string) => boolean
+}
+
+function navItemClass(isActive: boolean) {
+  return cn(
+    'flex min-w-0 flex-1 flex-col items-center justify-center gap-1 rounded-md px-1 py-2 text-[11px] transition-colors',
+    isActive ? 'text-foreground' : 'text-muted-foreground hover:text-foreground'
+  )
+}
+
+export function MobileBottomNav({ isAuthenticated, username }: MobileBottomNavProps) {
+  const pathname = usePathname()
+  const profileHref = username ? `/profile/${username}` : '/profile/settings'
+
+  const authItems: NavItem[] = [
+    { href: '/feed', label: 'Feed', icon: Home, active: (p) => p.startsWith('/feed') },
+    { href: '/explore', label: 'Explore', icon: Compass, active: (p) => p.startsWith('/explore') },
+    { href: '/prompts/new', label: 'New', icon: PlusSquare, active: (p) => p === '/prompts/new' },
+    { href: '/bookmarks', label: 'Saved', icon: Bookmark, active: (p) => p.startsWith('/bookmarks') },
+    { href: profileHref, label: 'Profile', icon: User, active: (p) => p.startsWith('/profile') },
+  ]
+
+  const guestItems: NavItem[] = [
+    { href: '/feed', label: 'Feed', icon: Home, active: (p) => p.startsWith('/feed') },
+    { href: '/explore', label: 'Explore', icon: Compass, active: (p) => p.startsWith('/explore') },
+    { href: '/login', label: 'Sign in', icon: LogIn, active: (p) => p.startsWith('/login') },
+    { href: '/signup', label: 'Sign up', icon: UserPlus, active: (p) => p.startsWith('/signup') },
+  ]
+
+  const items = isAuthenticated ? authItems : guestItems
+
+  return (
+    <nav className="fixed inset-x-0 bottom-0 z-50 border-t bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 sm:hidden">
+      <div className="mx-auto flex max-w-5xl items-center gap-1 px-2 pb-[calc(env(safe-area-inset-bottom)+0.35rem)] pt-2">
+        {items.map((item) => {
+          const Icon = item.icon
+          const active = item.active(pathname)
+
+          return (
+            <Link key={item.href} href={item.href} className={navItemClass(active)}>
+              <Icon className={cn('h-4 w-4', active && 'text-primary')} />
+              <span className="truncate">{item.label}</span>
+            </Link>
+          )
+        })}
+      </div>
+    </nav>
+  )
+}

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { signOut } from '@/lib/actions/auth'
 import { ThemeToggle } from '@/components/layout/theme-toggle'
+import { MobileBottomNav } from '@/components/layout/mobile-bottom-nav'
 import { Sparkles, Plus, Compass } from 'lucide-react'
 
 type NavProfile = { username: string; display_name: string | null; avatar_url: string | null }
@@ -30,76 +31,79 @@ export async function Navbar() {
   }
 
   return (
-    <header className="sticky top-0 z-50 border-b bg-background/80 backdrop-blur-sm">
-      <div className="mx-auto flex h-14 max-w-5xl items-center justify-between px-4">
-        <Link href="/feed" className="flex items-center gap-2 font-bold">
-          <Sparkles className="h-5 w-5 text-primary" />
-          PromptVault
-        </Link>
+    <>
+      <header className="sticky top-0 z-50 border-b bg-background/80 backdrop-blur-sm">
+        <div className="mx-auto flex h-14 max-w-5xl items-center justify-between px-4">
+          <Link href="/feed" className="flex items-center gap-2 font-bold">
+            <Sparkles className="h-5 w-5 text-primary" />
+            PromptVault
+          </Link>
 
-        <nav className="flex items-center gap-2">
-          <Button asChild variant="ghost" size="sm" className="hidden sm:flex">
-            <Link href="/explore">
-              <Compass className="mr-1 h-4 w-4" />
-              Explore
-            </Link>
-          </Button>
-          <ThemeToggle />
-          {user ? (
-            <>
-              <Button asChild size="sm">
-                <Link href="/prompts/new">
-                  <Plus className="mr-1 h-4 w-4" />
-                  New Prompt
-                </Link>
-              </Button>
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <button className="rounded-full outline-none ring-offset-background focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2">
-                    <Avatar className="h-8 w-8">
-                      <AvatarImage src={profile?.avatar_url ?? undefined} />
-                      <AvatarFallback>
-                        {(profile?.display_name ?? profile?.username ?? 'U')[0].toUpperCase()}
-                      </AvatarFallback>
-                    </Avatar>
-                  </button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" className="w-48">
-                  <DropdownMenuItem asChild>
-                    <Link href={`/profile/${profile?.username}`}>Profile</Link>
-                  </DropdownMenuItem>
-                  <DropdownMenuItem asChild>
-                    <Link href="/my-prompts">My Prompts</Link>
-                  </DropdownMenuItem>
-                  <DropdownMenuItem asChild>
-                    <Link href="/bookmarks">Bookmarks</Link>
-                  </DropdownMenuItem>
-                  <DropdownMenuItem asChild>
-                    <Link href="/profile/settings">Settings</Link>
-                  </DropdownMenuItem>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem asChild>
-                    <form action={signOut}>
-                      <button type="submit" className="w-full text-left">
-                        Sign out
-                      </button>
-                    </form>
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </>
-          ) : (
-            <>
-              <Button asChild variant="ghost" size="sm">
-                <Link href="/login">Sign in</Link>
-              </Button>
-              <Button asChild size="sm">
-                <Link href="/signup">Sign up</Link>
-              </Button>
-            </>
-          )}
-        </nav>
-      </div>
-    </header>
+          <nav className="flex items-center gap-2">
+            <Button asChild variant="ghost" size="sm" className="hidden sm:flex">
+              <Link href="/explore">
+                <Compass className="mr-1 h-4 w-4" />
+                Explore
+              </Link>
+            </Button>
+            <ThemeToggle />
+            {user ? (
+              <>
+                <Button asChild size="sm" className="hidden sm:inline-flex">
+                  <Link href="/prompts/new">
+                    <Plus className="mr-1 h-4 w-4" />
+                    New Prompt
+                  </Link>
+                </Button>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <button className="rounded-full outline-none ring-offset-background focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2">
+                      <Avatar className="h-8 w-8">
+                        <AvatarImage src={profile?.avatar_url ?? undefined} />
+                        <AvatarFallback>
+                          {(profile?.display_name ?? profile?.username ?? 'U')[0].toUpperCase()}
+                        </AvatarFallback>
+                      </Avatar>
+                    </button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" className="w-48">
+                    <DropdownMenuItem asChild>
+                      <Link href={`/profile/${profile?.username}`}>Profile</Link>
+                    </DropdownMenuItem>
+                    <DropdownMenuItem asChild>
+                      <Link href="/my-prompts">My Prompts</Link>
+                    </DropdownMenuItem>
+                    <DropdownMenuItem asChild>
+                      <Link href="/bookmarks">Bookmarks</Link>
+                    </DropdownMenuItem>
+                    <DropdownMenuItem asChild>
+                      <Link href="/profile/settings">Settings</Link>
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem asChild>
+                      <form action={signOut}>
+                        <button type="submit" className="w-full text-left">
+                          Sign out
+                        </button>
+                      </form>
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </>
+            ) : (
+              <>
+                <Button asChild variant="ghost" size="sm" className="hidden sm:inline-flex">
+                  <Link href="/login">Sign in</Link>
+                </Button>
+                <Button asChild size="sm" className="hidden sm:inline-flex">
+                  <Link href="/signup">Sign up</Link>
+                </Button>
+              </>
+            )}
+          </nav>
+        </div>
+      </header>
+      <MobileBottomNav isAuthenticated={!!user} username={profile?.username ?? undefined} />
+    </>
   )
 }


### PR DESCRIPTION
## Summary\n- add a mobile-only bottom navigation bar for main app routes\n- keep desktop navbar behavior unchanged\n- add bottom padding in main layout so content is not obscured by fixed nav\n\n## Files\n- src/components/layout/mobile-bottom-nav.tsx\n- src/components/layout/navbar.tsx\n- src/app/(main)/layout.tsx\n\n## Validation\n- npm run lint\n- npx tsc --noEmit