### PR TITLE
fix: safe defaults in notifications queries (fixes crash)

### DIFF
--- a/src/lib/queries/notifications.ts
+++ b/src/lib/queries/notifications.ts
@@ -30,7 +30,7 @@ export async function getNotifications(
     .order('created_at', { ascending: false })
     .range(page * limit, (page + 1) * limit - 1)
 
-  if (error) throw error
+  if (error) return []
 
   return (data ?? []) as unknown as NotificationWithRelations[]
 }
@@ -44,6 +44,6 @@ export async function getUnreadNotificationCount(recipientId: string): Promise<n
     .eq('recipient_id', recipientId)
     .eq('is_read', false)
 
-  if (error) throw error
+  if (error) return 0
   return count ?? 0
 }


### PR DESCRIPTION
Notifications queries were throwing on DB error, crashing the page and hitting the error boundary if the migrations haven't been run yet. Changed to return `[]` / `0` instead.