### PR TITLE
fix: broken feed — remove unrun migration columns from queries

### DIFF
--- a/src/lib/queries/profiles.ts
+++ b/src/lib/queries/profiles.ts
@@ -80,7 +80,7 @@ export async function getFollowers(userId: string, limit = 8): Promise<ProfilePr
     .order('created_at', { ascending: false })
     .limit(limit)
 
-  if (error) throw error
+  if (error) return []
 
   const rows = (data ?? []) as Array<{ follower: ProfilePreview | null }>
   return rows.flatMap((row) => (row.follower ? [row.follower] : []))
@@ -96,7 +96,7 @@ export async function getFollowing(userId: string, limit = 8): Promise<ProfilePr
     .order('created_at', { ascending: false })
     .limit(limit)
 
-  if (error) throw error
+  if (error) return []
 
   const rows = (data ?? []) as Array<{ followed: ProfilePreview | null }>
   return rows.flatMap((row) => (row.followed ? [row.followed] : []))


### PR DESCRIPTION
Codex added `usage_tips` and `example_output` to every query selector. Since that migration hasn't been run yet, Supabase returns an error on every feed/explore/bookmarks query, throwing and hitting the error boundary sitewide.

**Fix:**
- Remove `usage_tips`, `example_output` from `PROMPT_WITH_PROFILE` and all list queries (feed, search, bookmarks, my-prompts). Cards don't need these fields.
- `getPromptById` uses `SELECT *` so the detail page still gets them once the migration IS run.
- Replace all remaining `throw error` in queries with `return []` / `return 0` so no future DB issue can crash the whole site.