### PR TITLE
feat(seo): sitemap.xml and robots.txt — closes #30

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,16 @@
+import type { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://promptvaultt.netlify.app'
+
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: ['/api/', '/profile/settings', '/prompts/new', '/prompts/*/edit'],
+      },
+    ],
+    sitemap: `${siteUrl}/sitemap.xml`,
+  }
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,81 @@
+import type { MetadataRoute } from 'next'
+import { createClient } from '@/lib/supabase/server'
+
+export const revalidate = 3600 // regenerate hourly
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://promptvaultt.netlify.app'
+
+const STATIC_ROUTES: MetadataRoute.Sitemap = [
+  { url: SITE_URL, priority: 1.0, changeFrequency: 'daily' },
+  { url: `${SITE_URL}/feed`, priority: 0.9, changeFrequency: 'always' },
+  { url: `${SITE_URL}/explore`, priority: 0.8, changeFrequency: 'always' },
+  { url: `${SITE_URL}/creators`, priority: 0.7, changeFrequency: 'daily' },
+]
+
+async function getPromptUrls(): Promise<MetadataRoute.Sitemap> {
+  const supabase = await createClient()
+  const urls: MetadataRoute.Sitemap = []
+  const PAGE_SIZE = 1000
+  let page = 0
+
+  while (true) {
+    const { data, error } = await supabase
+      .from('prompts')
+      .select('id, updated_at')
+      .eq('is_public', true)
+      .order('created_at', { ascending: false })
+      .range(page * PAGE_SIZE, (page + 1) * PAGE_SIZE - 1)
+
+    if (error || !data?.length) break
+
+    for (const prompt of data) {
+      urls.push({
+        url: `${SITE_URL}/prompts/${prompt.id}`,
+        lastModified: new Date(prompt.updated_at),
+        changeFrequency: 'weekly',
+        priority: 0.6,
+      })
+    }
+
+    if (data.length < PAGE_SIZE) break
+    page++
+  }
+
+  return urls
+}
+
+async function getProfileUrls(): Promise<MetadataRoute.Sitemap> {
+  const supabase = await createClient()
+  const urls: MetadataRoute.Sitemap = []
+  const PAGE_SIZE = 1000
+  let page = 0
+
+  while (true) {
+    const { data, error } = await supabase
+      .from('profiles')
+      .select('username, updated_at')
+      .order('follower_count', { ascending: false })
+      .range(page * PAGE_SIZE, (page + 1) * PAGE_SIZE - 1)
+
+    if (error || !data?.length) break
+
+    for (const profile of data) {
+      urls.push({
+        url: `${SITE_URL}/profile/${profile.username}`,
+        lastModified: new Date(profile.updated_at),
+        changeFrequency: 'weekly',
+        priority: 0.5,
+      })
+    }
+
+    if (data.length < PAGE_SIZE) break
+    page++
+  }
+
+  return urls
+}
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const [promptUrls, profileUrls] = await Promise.all([getPromptUrls(), getProfileUrls()])
+  return [...STATIC_ROUTES, ...promptUrls, ...profileUrls]
+}


### PR DESCRIPTION
## Summary
- **`/robots.txt`** — allows all crawlers on public pages, blocks `/api/`, `/profile/settings`, `/prompts/new`, edit pages
- **`/sitemap.xml`** — dynamically generated, revalidated hourly:
  - Static routes: `/`, `/feed`, `/explore`, `/creators`
  - All public prompts (paginated 1000/page, ordered newest first)
  - All profiles (paginated 1000/page, ordered by follower count)

## Test plan
- [ ] Visit `/robots.txt` — see rules + sitemap URL
- [ ] Visit `/sitemap.xml` — see all public prompt and profile URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)