### PR TITLE
rebrand: The Permanent Archive for AI Prompts

### DIFF
--- a/src/app/(main)/feed/page.tsx
+++ b/src/app/(main)/feed/page.tsx
@@ -11,7 +11,7 @@ import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Users } from 'lucide-react'
 
-export const metadata = { title: 'Feed — PromptVault' }
+export const metadata = { title: 'Feed — PromptVault: The Permanent Archive' }
 
 const PAGE_SIZE = 20
 
@@ -193,8 +193,8 @@ export default async function FeedPage({
       <div className="rounded-xl bg-gradient-to-br from-primary/10 via-primary/5 to-transparent p-6 border border-primary/10">
         <div className="flex items-center justify-between flex-wrap gap-3">
           <div>
-            <h1 className="text-2xl font-bold">Discover Prompts</h1>
-            <p className="text-sm text-muted-foreground mt-0.5">Browse the best prompts for Claude, ChatGPT, Gemini &amp; more</p>
+            <h1 className="text-2xl font-bold">The Archive</h1>
+            <p className="text-sm text-muted-foreground mt-0.5">Prompts worth preserving — for Claude, ChatGPT, Gemini &amp; more</p>
           </div>
           <Suspense>
             <FeedTabs isAuthenticated={!!user} />

--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -38,6 +38,7 @@ export async function GET(req: NextRequest) {
           <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
             <div style={{ fontSize: 24, color: accent }}>✦</div>
             <div style={{ fontSize: 22, fontWeight: 700, color: white, letterSpacing: '-0.5px' }}>PromptVault</div>
+            <div style={{ fontSize: 12, color: muted, marginLeft: 8 }}>The Permanent Archive</div>
           </div>
 
           {/* Profile block */}
@@ -125,6 +126,7 @@ export async function GET(req: NextRequest) {
           <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
             <div style={{ fontSize: 24, color: accent }}>✦</div>
             <div style={{ fontSize: 22, fontWeight: 700, color: white, letterSpacing: '-0.5px' }}>PromptVault</div>
+            <div style={{ fontSize: 12, color: muted, marginLeft: 8 }}>The Permanent Archive</div>
           </div>
           {category && (
             <div

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,9 +7,9 @@ import { Toaster } from '@/components/ui/sonner'
 const geist = Geist({ subsets: ['latin'], variable: '--font-geist-sans' })
 
 export const metadata: Metadata = {
-  title: 'PromptVault — Share and Discover AI Prompts',
+  title: 'PromptVault — The Permanent Archive for AI Prompts',
   description:
-    'The social platform for AI prompt art. Share your best ChatGPT, Claude, and Gemini interactions. Discover how others use AI creatively.',
+    'The right prompt can change everything. PromptVault is the permanent archive where the best prompts for Claude, ChatGPT, and Gemini are preserved, shared, and remembered forever.',
 }
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,7 @@ import { getFeedPrompts } from '@/lib/queries/prompts'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
-import { Sparkles, ArrowRight, Heart, Star } from 'lucide-react'
+import { Sparkles, ArrowRight, Heart, Star, Archive, Clock, GitFork } from 'lucide-react'
 import { CATEGORY_META } from '@/lib/category-icons'
 import type { PromptCategory } from '@/types/database'
 
@@ -30,7 +30,6 @@ export default async function HomePage() {
     data: { user },
   } = await supabase.auth.getUser()
 
-  // Logged-in users go straight to their feed
   if (user) redirect('/feed')
 
   const trending = await getFeedPrompts({ tab: 'trending', limit: 6 })
@@ -38,39 +37,68 @@ export default async function HomePage() {
   return (
     <div className="flex flex-col gap-20 pb-20">
       {/* ── Hero ── */}
-      <section className="relative mx-auto max-w-3xl px-4 pt-16 pb-8 text-center">
-        {/* Soft glow behind headline */}
+      <section className="relative mx-auto max-w-3xl px-4 pt-20 pb-8 text-center">
         <div className="pointer-events-none absolute inset-0 -top-10 flex justify-center">
           <div className="h-72 w-72 rounded-full bg-primary/20 blur-3xl" />
         </div>
 
         <div className="relative">
           <Badge variant="secondary" className="mb-4 gap-1.5">
-            <Sparkles className="h-3 w-3 text-primary" />
-            The home for AI prompts
+            <Archive className="h-3 w-3 text-primary" />
+            The permanent archive for AI prompts
           </Badge>
 
           <h1 className="text-4xl font-extrabold tracking-tight sm:text-6xl">
-            Share prompts.
+            Your prompts deserve
             <br />
-            <span className="text-primary">Inspire others.</span>
+            <span className="text-primary">to live forever.</span>
           </h1>
 
           <p className="mx-auto mt-5 max-w-xl text-lg text-muted-foreground">
-            Discover and share the best prompts for Claude, ChatGPT, Gemini, and more — built by a
-            community of prompt engineers.
+            The right prompt can change everything. PromptVault is where the best prompts for
+            Claude, ChatGPT, Gemini, and more are preserved, shared, and remembered — forever.
           </p>
 
           <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
             <Button asChild size="lg">
               <Link href="/feed">
-                Browse Prompts
+                Explore the archive
                 <ArrowRight className="ml-2 h-4 w-4" />
               </Link>
             </Button>
             <Button asChild size="lg" variant="outline">
-              <Link href="/signup">Sign up free</Link>
+              <Link href="/signup">Start preserving</Link>
             </Button>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Philosophy ── */}
+      <section className="mx-auto w-full max-w-5xl px-4">
+        <div className="grid gap-6 sm:grid-cols-3">
+          <div className="rounded-xl border bg-card p-6 text-center space-y-2">
+            <Archive className="mx-auto h-8 w-8 text-primary" />
+            <h3 className="font-bold">Permanent archive</h3>
+            <p className="text-sm text-muted-foreground">
+              Like archive.org but for prompts. Every prompt you save here is preserved and
+              timestamped forever.
+            </p>
+          </div>
+          <div className="rounded-xl border bg-card p-6 text-center space-y-2">
+            <Sparkles className="mx-auto h-8 w-8 text-primary" />
+            <h3 className="font-bold">Digital art of AI</h3>
+            <p className="text-sm text-muted-foreground">
+              Prompts are creative artifacts. The best ones are crafted, refined, and deserve
+              to be recognized as works of art.
+            </p>
+          </div>
+          <div className="rounded-xl border bg-card p-6 text-center space-y-2">
+            <GitFork className="mx-auto h-8 w-8 text-primary" />
+            <h3 className="font-bold">Remix and evolve</h3>
+            <p className="text-sm text-muted-foreground">
+              Fork any prompt, build on it, trace its lineage. Great prompts evolve through
+              community collaboration.
+            </p>
           </div>
         </div>
       </section>
@@ -81,7 +109,7 @@ export default async function HomePage() {
           <div className="mb-6 flex items-center justify-between">
             <h2 className="text-xl font-bold">
               <Star className="mr-2 inline h-5 w-5 text-primary" />
-              Trending this week
+              Most loved this week
             </h2>
             <Button asChild variant="ghost" size="sm">
               <Link href="/feed?tab=trending">
@@ -100,30 +128,29 @@ export default async function HomePage() {
                   href={`/prompts/${prompt.id}`}
                   className="group flex flex-col gap-3 rounded-xl border bg-card p-4 hover:shadow-lg hover:-translate-y-0.5 transition-all duration-200"
                 >
-                  {/* Author */}
-                  <div className="flex items-center gap-2.5">
-                    <Avatar className="h-7 w-7">
-                      <AvatarImage src={profile.avatar_url ?? undefined} />
-                      <AvatarFallback className="text-xs">
-                        {(profile.display_name ?? profile.username ?? 'U')[0].toUpperCase()}
-                      </AvatarFallback>
-                    </Avatar>
-                    <span className="text-xs font-medium text-muted-foreground">
-                      {profile.display_name ?? profile.username}
-                    </span>
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2.5">
+                      <Avatar className="h-7 w-7">
+                        <AvatarImage src={profile.avatar_url ?? undefined} />
+                        <AvatarFallback className="text-xs">
+                          {(profile.display_name ?? profile.username ?? 'U')[0].toUpperCase()}
+                        </AvatarFallback>
+                      </Avatar>
+                      <span className="text-xs font-medium text-muted-foreground">
+                        {profile.display_name ?? profile.username}
+                      </span>
+                    </div>
+                    <Clock className="h-3 w-3 text-muted-foreground/50" />
                   </div>
 
-                  {/* Title */}
                   <h3 className="font-semibold leading-snug line-clamp-2 group-hover:text-primary transition-colors">
                     {prompt.title}
                   </h3>
 
-                  {/* Excerpt */}
                   <p className="text-xs text-muted-foreground font-mono line-clamp-3 bg-muted/40 rounded-md p-2">
                     {prompt.content}
                   </p>
 
-                  {/* Footer */}
                   <div className="flex items-center justify-between">
                     <div className="flex gap-1">
                       {catMeta && (
@@ -150,7 +177,7 @@ export default async function HomePage() {
 
       {/* ── Categories ── */}
       <section className="mx-auto w-full max-w-5xl px-4">
-        <h2 className="mb-6 text-xl font-bold">Browse by category</h2>
+        <h2 className="mb-6 text-xl font-bold">Browse the archive</h2>
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-5">
           {CATEGORIES.map(([key, meta]) => (
             <Link
@@ -169,15 +196,15 @@ export default async function HomePage() {
       <section className="mx-auto w-full max-w-3xl px-4">
         <div className="relative overflow-hidden rounded-2xl border bg-gradient-to-br from-primary/15 via-primary/5 to-transparent p-10 text-center">
           <div className="pointer-events-none absolute -right-10 -top-10 h-40 w-40 rounded-full bg-primary/20 blur-3xl" />
-          <Sparkles className="mx-auto mb-4 h-8 w-8 text-primary" />
-          <h2 className="text-2xl font-bold">Ready to share your prompts?</h2>
-          <p className="mt-2 text-muted-foreground">
-            Join thousands of prompt engineers sharing their best work.
+          <Archive className="mx-auto mb-4 h-8 w-8 text-primary" />
+          <h2 className="text-2xl font-bold">One prompt away from a brighter future.</h2>
+          <p className="mt-2 text-muted-foreground max-w-md mx-auto">
+            Don&apos;t let your best prompts disappear into chat history. Preserve them. Share them. Let them inspire the next breakthrough.
           </p>
           <div className="mt-6 flex flex-wrap justify-center gap-3">
             <Button asChild size="lg">
               <Link href="/signup">
-                Get started free
+                Start your archive
                 <ArrowRight className="ml-2 h-4 w-4" />
               </Link>
             </Button>


### PR DESCRIPTION
## Summary
Rebrands PromptVault around the archive.org-for-prompts philosophy: prompts are digital art that deserve to be preserved forever.

**Landing page:**
- Hero: *'Your prompts deserve to live forever.'*
- New philosophy section with 3 pillars: Permanent Archive, Digital Art of AI, Remix & Evolve
- CTA: *'One prompt away from a brighter future. Don't let your best prompts disappear into chat history.'*
- Section headers updated: 'Most loved this week', 'Browse the archive'

**Site-wide:**
- Root metadata: 'PromptVault — The Permanent Archive for AI Prompts'
- Feed header: 'The Archive' with 'Prompts worth preserving'
- OG images: 'The Permanent Archive' tagline next to logo

## Test plan
- [ ] Visit `/` logged out — see new archive-themed landing page
- [ ] Check page title in browser tab — see 'The Permanent Archive' tagline
- [ ] Share a prompt link — OG image shows 'The Permanent Archive' tagline

🤖 Generated with [Claude Code](https://claude.com/claude-code)